### PR TITLE
Update sidekiq_timeout

### DIFF
--- a/lib/mina_sidekiq/tasks.rb
+++ b/lib/mina_sidekiq/tasks.rb
@@ -37,8 +37,8 @@ set_default :sidekiq, lambda { "#{bundle_bin} exec sidekiq" }
 set_default :sidekiqctl, lambda { "#{bundle_prefix} sidekiqctl" }
 
 # ### sidekiq_timeout
-# Sets a upper limit of time a worker is allowed to finish, before it is killed.
-set_default :sidekiq_timeout, 10
+# Sets a upper limit of time a process is allowed to finish, before it is killed by sidekiqctl.
+set_default :sidekiq_timeout, 11
 
 # ### sidekiq_config
 # Sets the path to the configuration file of sidekiq


### PR DESCRIPTION
This constant should be **larger** than 10 because it's the amount of time sidekiqctl will wait for sidekiq to exit.  Sidekiq should exit within N seconds of receiving TERM so you want to wait N+1 seconds to give it the full amount of time to exit, where N defaults to 10.