### PR TITLE
Default `sidekiq_concurrency` to nil. #13

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
++0.4.1 2016-05-27
+ +----------------
+ +* Default `sidekiq_concurrency` to nil. It now needs explicitly set to
+ override concurrency specified in config file
+
 0.4.0 2016-05-16
 ----------------
 

--- a/lib/mina_sidekiq/version.rb
+++ b/lib/mina_sidekiq/version.rb
@@ -1,5 +1,5 @@
 module MinaSidekiq
   def self.version
-    "0.4.0"
+    "0.4.1"
   end
 end


### PR DESCRIPTION
:sidekiq_concurrency now needs explicitly set in deploy.rb to override concurrency specified in sidekiq.yml config file - relating to Issue #13 and pull request #12 