### PR TITLE
Fixed bug: undefined variable named sidekiq_log

### DIFF
--- a/lib/mina_sidekiq/tasks.rb
+++ b/lib/mina_sidekiq/tasks.rb
@@ -134,6 +134,6 @@ namespace :sidekiq do
 
   desc "Tail log from server"
   task :log => :environment do
-    command %[tail -f #{sidekiq_log}]
+    command %[tail -f #{fetch(:sidekiq_log)}]
   end
 end


### PR DESCRIPTION
Fixed the code to retrieve the proper variable. Caused
"NameError: undefined local variable or method `sidekiq_log' for main:Object" error.