### PR TITLE
mina has deprecated `environment` task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,7 @@ cache: bundler
 rvm:
   - "2.2.5"
   - "2.3.1"
-services: redis
 
 before_install:
   - ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa
   - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
-  - echo "Host localhost" >> /home/travis/.ssh/config
-  - echo "  StrictHostKeyChecking no" >> /home/travis/.ssh/config
-  - chmod g-rw,o-rw /home/travis/.ssh/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 cache: bundler
-sudo: false
 rvm:
   - "2.2.5"
   - "2.3.1"

--- a/lib/mina_sidekiq/tasks.rb
+++ b/lib/mina_sidekiq/tasks.rb
@@ -76,7 +76,7 @@ namespace :sidekiq do
 
   # ### sidekiq:quiet
   desc "Quiet sidekiq (stop accepting new work)"
-  task :quiet => :environment do
+  task :quiet => :remote_environment do
     comment 'Quiet sidekiq (stop accepting new work)'
     in_path(fetch(:current_path)) do
       for_each_process do |pid_file, idx|
@@ -93,7 +93,7 @@ namespace :sidekiq do
 
   # ### sidekiq:stop
   desc "Stop sidekiq"
-  task :stop => :environment do
+  task :stop => :remote_environment do
     comment 'Stop sidekiq'
     in_path(fetch(:current_path)) do
       for_each_process do |pid_file, idx|
@@ -110,7 +110,7 @@ namespace :sidekiq do
 
   # ### sidekiq:start
   desc "Start sidekiq"
-  task :start => :environment do
+  task :start => :remote_environment do
     comment 'Start sidekiq'
     in_path(fetch(:current_path)) do
       for_each_process do |pid_file, idx|
@@ -133,7 +133,7 @@ namespace :sidekiq do
   end
 
   desc "Tail log from server"
-  task :log => :environment do
+  task :log => :remote_environment do
     command %[tail -f #{fetch(:sidekiq_log)}]
   end
 end

--- a/test_env/config/deploy.rb
+++ b/test_env/config/deploy.rb
@@ -14,11 +14,11 @@ set :repository, 'https://github.com/Mic92/mina-sidekiq-test-rails.git'
 set :keep_releases, 2
 set :sidekiq_processes, 2
 
-task :environment do
+task :remote_environment do
   invoke :'rvm:use', ENV.fetch('RUBY_VERSION', 'ruby-2.3.1')
 end
 
-task setup: :environment do
+task setup: :remote_environment do
   command %(mkdir -p "#{fetch(:deploy_to)}/shared/pids/")
   command %(mkdir -p "#{fetch(:deploy_to)}/shared/log/")
 end


### PR DESCRIPTION
Fixes #26

[The docs][6] says, "Remove :environment dependency on all your tasks", but that's probably targeting user's `deploy.rb` file.

From what I can see, `mina` does [invoke][1] `remote_environment` when [`deploy`][2] method is called. But the effect can't be seen, for example, inside [`on (:launch)`][3] block, since it gets [executed][4] in a separate [subshell][5]. So, environment variables, among other things, set in `remote_environment` would not be available in `on (:launch)` block, unless tasks executed in it depend on `remote_environment`. As such, ditching dependency on `remote_environment` doesn't seem like an option.

[6]: https://github.com/mina-deploy/mina/blob/master/docs/migrating.md#dsl

[1]: https://github.com/mina-deploy/mina/blob/v1.2.2/lib/mina/dsl.rb#L51
[2]: https://github.com/mina-deploy/mina/blob/v1.2.2/lib/mina/dsl.rb#L29

[3]: https://github.com/mina-deploy/mina/blob/v1.2.2/lib/mina/dsl.rb#L37
[4]: https://github.com/mina-deploy/mina/blob/v1.2.2/data/deploy.sh.erb#L4
[5]: https://github.com/mina-deploy/mina/blob/v1.2.2/data/deploy.sh.erb#L85