### PR TITLE
Allow one config file per process

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,16 @@ end
 
 ## Available Options
 
-| Option              | Description                                                                    |
-| ------------------- | ------------------------------------------------------------------------------ |
-| *sidekiq*           | Sets the path to sidekiq.                                                      |
-| *sidekiqctl*        | Sets the path to sidekiqctl.                                                   |
-| *sidekiq\_timeout*  | Sets a upper limit of time a worker is allowed to finish, before it is killed. |
-| *sidekiq\_log*      | Sets the path to the log file of sidekiq.                                      |
-| *sidekiq\_pid*      | Sets the path to the pid file of a sidekiq worker.                             |
-| *sidekiq_processes* | Sets the number of sidekiq processes launched.                                 |
+| Option              | Description                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------- |
+| *sidekiq*           | Sets the path to sidekiq.                                                                         |
+| *sidekiqctl*        | Sets the path to sidekiqctl.                                                                      |
+| *sidekiq\_timeout*  | Sets a upper limit of time a worker is allowed to finish, before it is killed.                    |
+| *sidekiq\_log*      | Sets the path to the log file of sidekiq.                                                         |
+| *sidekiq\_pid*      | Sets the path to the pid file of a sidekiq worker.                                                |
+| *sidekiq_processes* | Sets the number of sidekiq processes launched.                                                    |
+| *sidekiq_config*    | Sets the config file path.                                                                        |
+| *sidekiq_configs*   | Sets the config file paths when using more than one sidekiq process with different configuration. |
 
 ## Testing
 

--- a/lib/mina_sidekiq/tasks.rb
+++ b/lib/mina_sidekiq/tasks.rb
@@ -44,7 +44,8 @@ set :sidekiq_timeout, 11
 set :sidekiq_config, -> { "#{fetch(:current_path)}/config/sidekiq.yml" }
 
 # ### sidekiq_configs
-# Sets the path to the configurations files of sidekiq when using more than one sidekiq process.
+# A list of configuration file paths. Each file path will be assigned to one sidekiq
+# instance in order. When specified sidekiq_config will be ignored.
 set :sidekiq_configs, -> {
   [
     # "#{fetch(:current_path)}/config/sidekiq_1.yml",

--- a/lib/mina_sidekiq/tasks.rb
+++ b/lib/mina_sidekiq/tasks.rb
@@ -40,8 +40,17 @@ set :sidekiqctl, -> { "#{fetch(:bundle_prefix)} sidekiqctl" }
 set :sidekiq_timeout, 11
 
 # ### sidekiq_config
-# Sets the path to the configuration file of sidekiq
+# Sets the path to the configuration file of sidekiq.
 set :sidekiq_config, -> { "#{fetch(:current_path)}/config/sidekiq.yml" }
+
+# ### sidekiq_configs
+# Sets the path to the configurations files of sidekiq when using more than one sidekiq process.
+set :sidekiq_configs, -> {
+  [
+    # "#{fetch(:current_path)}/config/sidekiq_1.yml",
+    # "#{fetch(:current_path)}/config/sidekiq_2.yml"
+  ]
+}
 
 # ### sidekiq_log
 # Sets the path to the log file of sidekiq
@@ -114,13 +123,14 @@ namespace :sidekiq do
     comment 'Start sidekiq'
     in_path(fetch(:current_path)) do
       for_each_process do |pid_file, idx|
+        sidekiq_config = fetch(:sidekiq_configs)[idx] || fetch(:sidekiq_config)
         sidekiq_concurrency = fetch(:sidekiq_concurrency)
         concurrency_arg = if sidekiq_concurrency.nil?
                             ""
                           else
                             "-c #{sidekiq_concurrency}"
                           end
-        command %[#{fetch(:sidekiq)} -d -e #{fetch(:rails_env)} #{concurrency_arg} -C #{fetch(:sidekiq_config)} -i #{idx} -P #{pid_file} -L #{fetch(:sidekiq_log)}]
+        command %[#{fetch(:sidekiq)} -d -e #{fetch(:rails_env)} #{concurrency_arg} -C #{sidekiq_config} -i #{idx} -P #{pid_file} -L #{fetch(:sidekiq_log)}]
       end
     end
   end


### PR DESCRIPTION
Allow the usage of more than one sidekiq process but with different
config files.

Usage: set sidekiq_configs to an array of configurations.