### PR TITLE
Use bundle_bin instead of bundle_prefix for sidekiqctl execution

### DIFF
--- a/lib/mina_sidekiq/tasks.rb
+++ b/lib/mina_sidekiq/tasks.rb
@@ -33,7 +33,7 @@ set :sidekiq, -> { "#{fetch(:bundle_bin)} exec sidekiq" }
 
 # ### sidekiqctl
 # Sets the path to sidekiqctl.
-set :sidekiqctl, -> { "#{fetch(:bundle_prefix)} sidekiqctl" }
+set :sidekiqctl, -> { "#{fetch(:bundle_bin)} exec sidekiqctl" }
 
 # ### sidekiq_timeout
 # Sets a upper limit of time a process is allowed to finish, before it is killed by sidekiqctl.


### PR DESCRIPTION
`bundle_prefix` is defined in `mina/rails` plugin. So, if we use Sidekiq without Rails, commands like `sidekiq:squiet` and `sidekiq:stop` do not work.