### PR TITLE
Fix sidekiq 6 support, adopt it for non privileged user (non sudo) usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,27 @@ Default systemctl command is ```systemctl --user```, this can be changed, for ex
 ```ruby
   set :systemctl_command, 'systemctl --user'
 ```
+For non privileged user (non sudo) usage set up path for systemctl unit file:
+
+```ruby
+  set :service_unit_path, '/home/www/.config/systemd/user'
+```
+
+where ```www``` is the username. For details see systemctl [doc page](https://www.freedesktop.org/software/systemd/man/systemd.unit.html) 
+
+To use systemctl integration with rbenv bundler path must be setted:
+
+```ruby
+  set :bundler_path, '/home/www/.rbenv/shims/bundler'
+```
+
+To get bundler path use:
+
+```bash
+  which bundler
+```
+
+
 ## Integration with upstart
 
 Set init system to upstart in the cap deploy config:

--- a/README.md
+++ b/README.md
@@ -68,9 +68,14 @@ Install systemd.service template file and enable the service with:
 Default name for the service file is sidekiq-env.service. This can be changed as needed, for example:
 
 ```ruby
-  set :service_unit_name, "sidekiq-#{fetch(:rails_env)}}.service"
+  set :service_unit_name, "sidekiq-#{fetch(:rails_env)}.service"
 ```
 
+Default systemctl command is ```systemctl --user```, this can be changed, for example:
+
+```ruby
+  set :systemctl_command, 'systemctl --user'
+```
 ## Integration with upstart
 
 Set init system to upstart in the cap deploy config:

--- a/lib/mina_sidekiq/tasks.rb
+++ b/lib/mina_sidekiq/tasks.rb
@@ -186,7 +186,28 @@ namespace :sidekiq do
   end
 
   def create_systemd_template
-    template =  "[Unit]\nDescription=sidekiq for #{fetch(:application)} #{fetch(:app_name)}\nAfter=syslog.target network.target\n\n[Service]\nType=simple\nEnvironment=RAILS_ENV=#{ fetch(:rails_env) }\nStandardOutput=append:#{fetch(:deploy_to)}/current/log/sidekiq.log\nStandardError=append:#{fetch(:deploy_to)}/current/log/sidekiq.log\nWorkingDirectory=#{fetch(:deploy_to)}/current\nExecStart=#{fetch(:bundler_path, '/usr/local/bin/bundler')} exec sidekiq -e #{fetch(:rails_env)}\nExecReload=/bin/kill -TSTP $MAINPID\nExecStop=/bin/kill -TERM $MAINPID\n\nRestartSec=1\nRestart=on-failure\n\nSyslogIdentifier=sidekiq\n\n[Install]\nWantedBy=default.target\n"
+    template =  %{
+[Unit]
+Description=sidekiq for #{fetch(:application)} #{fetch(:app_name)}
+After=syslog.target network.target
+
+[Service]
+Type=simple
+Environment=RAILS_ENV=#{ fetch(:rails_env) }
+StandardOutput=append:#{fetch(:deploy_to)}/current/log/sidekiq.log
+StandardError=append:#{fetch(:deploy_to)}/current/log/sidekiq.log
+WorkingDirectory=#{fetch(:deploy_to)}/current
+ExecStart=#{fetch(:bundler_path, '/usr/local/bin/bundler')} exec sidekiq -e #{fetch(:rails_env)}
+ExecReload=/bin/kill -TSTP $MAINPID
+ExecStop=/bin/kill -TERM $MAINPID
+RestartSec=1
+Restart=on-failure
+
+SyslogIdentifier=sidekiq
+
+[Install]
+WantedBy=default.target
+}
     systemd_path = fetch(:service_unit_path, fetch_systemd_unit_path)
     service_path = systemd_path + "/" + fetch(:service_unit_name)
     comment %{Creating systemctl unit file}


### PR DESCRIPTION
This PR adds the ability for non-privileged users to use systemctl to control sidekiq, adding support for the ```systemctl --user``` command